### PR TITLE
Fix: Fix typo Contatc -> Contact

### DIFF
--- a/components/NavBar/index.jsx
+++ b/components/NavBar/index.jsx
@@ -29,7 +29,7 @@ export default function Navbar() {
           </li>
           <li>
             <Link href="/contact">
-              <a>Contatc</a>
+              <a>Contact</a>
             </Link>
           </li>
         </ul>


### PR DESCRIPTION
Olá!

Na barra de navegação no topo do site existe um erro de ortografia em inglês. A palavra correta é `Contact` mas no site está escrito `Contatc`. Esse request retifica o erro de ortografia.

Criei uma branch separada para consertar o problema e aguardo a revisão do Maintainer.

Esse commit resolve a issue #2 

Obrigado pela atenção. 
_João Pedro_